### PR TITLE
Fix issue #8, shrink DSP buffer size to 512

### DIFF
--- a/skymen_fmod_js/src/domSide.js
+++ b/skymen_fmod_js/src/domSide.js
@@ -319,7 +319,7 @@
       this.assert(this.gSystem.getCoreSystem(outval));
       this.gSystemCore = outval.val;
 
-      this.assert(this.gSystemCore.setDSPBufferSize(2048, 2));
+      this.assert(this.gSystemCore.setDSPBufferSize(512, 2));
       this.assert(
         this.gSystemCore.getDriverInfo(0, null, null, outval, null, null)
       );
@@ -335,7 +335,7 @@
         this.gSystem.setAdvancedSettings({
           commandqueuesize: 0,
           handleinitialsize: 0,
-          studioupdateperiod: 5,
+          studioupdateperiod: 20,
           idlesampledatapoolsize: 0,
           streamingscheduledelay: 0,
         })


### PR DESCRIPTION
Fixes https://github.com/skymen/fmod/issues/8 by shrinking the DSP buffer size down to 512. Some people who were using the WebGL export on the Unity forms had luck fixing skipping problems by reducing this (see https://qa.fmod.com/t/webgl-stuttering-audio-too-problematic-with-fmod/18834/9).

This PR also reverts the Studio update period back to 20 as setting it to 5 didn't seem to affect the playback bug.